### PR TITLE
Home menu improvements

### DIFF
--- a/720p/Home.xml
+++ b/720p/Home.xml
@@ -1,5 +1,10 @@
 <window id="0">
-	<defaultcontrol always="true">9000</defaultcontrol>
+	<!-- convert existing backspacehome setting to string -->
+	<onload condition="Skin.HasSetting(backspacehome.enable) + !Skin.HasSetting(backspacehome.upgraded)">Skin.SetString(backspacehome, return)</onload>
+	<onload condition="!Skin.HasSetting(backspacehome.upgraded)">Skin.SetBool(backspacehome.upgraded)</onload>
+	<!-- -->
+
+	<defaultcontrol always="false">9000</defaultcontrol>
 	<allowoverlay>no</allowoverlay>
 	
 

--- a/720p/HomeSubMenu.xml
+++ b/720p/HomeSubMenu.xml
@@ -20,56 +20,56 @@
 				<content>
 					<item id="1">
 						<label>$LOCALIZE[1024]</label>
-						<onclick>ActivateWindow(Videos,Files)</onclick>
+						<onclick>ActivateWindow(Videos,Files,$INFO[Skin.String(backspacehome)])</onclick>
 					</item>
 					<item id="2">
 						<label>$INFO[Skin.String(videomenu.playlist1.label)]</label>
-						<onclick>ActivateWindow(videolibrary,$INFO[Skin.String(videomenu.playlist1.path)],return)</onclick>
+						<onclick>ActivateWindow(videolibrary,$INFO[Skin.String(videomenu.playlist1.path)],$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>!IsEmpty(Skin.String(videomenu.playlist1.path)) + !Skin.HasSetting(favourites.global)</visible>
 					</item>
 					<item id="3">
 						<label>$INFO[Skin.String(videomenu.playlist2.label)]</label>
-						<onclick>ActivateWindow(videolibrary,$INFO[Skin.String(videomenu.playlist2.path)],return)</onclick>
+						<onclick>ActivateWindow(videolibrary,$INFO[Skin.String(videomenu.playlist2.path)],$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>!IsEmpty(Skin.String(videomenu.playlist2.path)) + !Skin.HasSetting(favourites.global)</visible>
 					</item>
 					<item id="4">
 						<label>$INFO[Skin.String(videomenu.playlist3.label)]</label>
-						<onclick>ActivateWindow(videolibrary,$INFO[Skin.String(videomenu.playlist3.path)],return)</onclick>
+						<onclick>ActivateWindow(videolibrary,$INFO[Skin.String(videomenu.playlist3.path)],$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>!IsEmpty(Skin.String(videomenu.playlist3.path)) + !Skin.HasSetting(favourites.global)</visible>
 					</item>
 					<item id="5">
 						<label>$INFO[Skin.String(videomenu.playlist4.label)]</label>
-						<onclick>ActivateWindow(videolibrary,$INFO[Skin.String(videomenu.playlist4.path)],return)</onclick>
+						<onclick>ActivateWindow(videolibrary,$INFO[Skin.String(videomenu.playlist4.path)],$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>!IsEmpty(Skin.String(videomenu.playlist4.path)) + !Skin.HasSetting(favourites.global)</visible>
 					</item>
 					<item id="6">
 						<label>$INFO[Skin.String(videomenu.playlist5.label)]</label>
-						<onclick>ActivateWindow(Videos,$INFO[Skin.String(videomenu.playlist5.path)],return)</onclick>
+						<onclick>ActivateWindow(Videos,$INFO[Skin.String(videomenu.playlist5.path)],$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>!IsEmpty(Skin.String(videomenu.playlist5.path)) + !Skin.HasSetting(favourites.global)</visible>
 					</item>
 					<item id="7">
 						<label>$INFO[Skin.String(videomenu.playlist6.label)]</label>
-						<onclick>ActivateWindow(Videos,$INFO[Skin.String(videomenu.playlist6.path)],return)</onclick>
+						<onclick>ActivateWindow(Videos,$INFO[Skin.String(videomenu.playlist6.path)],$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>!IsEmpty(Skin.String(videomenu.playlist6.path)) + !Skin.HasSetting(favourites.global)</visible>
 					</item>
 					<item id="8">
 						<label>$INFO[Skin.String(videomenu.playlist7.label)]</label>
-						<onclick>ActivateWindow(Videos,$INFO[Skin.String(videomenu.playlist7.path)],return)</onclick>
+						<onclick>ActivateWindow(Videos,$INFO[Skin.String(videomenu.playlist7.path)],$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>!IsEmpty(Skin.String(videomenu.playlist7.path)) + !Skin.HasSetting(favourites.global)</visible>
 					</item>
 					<item id="9">
 						<label>$INFO[Skin.String(videomenu.playlist8.label)]</label>
-						<onclick>ActivateWindow(Videos,$INFO[Skin.String(videomenu.playlist8.path)],return)</onclick>
+						<onclick>ActivateWindow(Videos,$INFO[Skin.String(videomenu.playlist8.path)],$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>!IsEmpty(Skin.String(videomenu.playlist8.path)) + !Skin.HasSetting(favourites.global)</visible>
 					</item>
 					<item id="10">
 						<label>$LOCALIZE[24001]</label>
-						<onclick>ActivateWindow(VideoLibrary,Addons,return)</onclick>
+						<onclick>ActivateWindow(VideoLibrary,Addons,$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>!Skin.HasSetting(videomenu.addons)</visible>
 					</item>
 					<item id="11">
 						<label>$LOCALIZE[136]</label>
-						<onclick>ActivateWindow(videolibrary,playlists, return)</onclick>
+						<onclick>ActivateWindow(videolibrary,playlists, $INFO[Skin.String(backspacehome)])</onclick>
 						<visible>!Skin.HasSetting(videomenu.videoplaylists)</visible>
 					</item>
 					<item id="12">
@@ -181,73 +181,38 @@
 				<content>
 					<item id="1">
 						<label>$LOCALIZE[132]</label>
-						<onclick>ActivateWindow(MusicLibrary,albums)</onclick>
-						<visible>Library.HasContent(music) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="1">
-						<label>$LOCALIZE[132]</label>
-						<onclick>ActivateWindow(MusicLibrary,albums,return)</onclick>
-						<visible>Library.HasContent(music) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(MusicLibrary,albums,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Library.HasContent(music)</visible>
 					</item>
 					<item id="2">
 						<label>$LOCALIZE[31970]</label>
-						<onclick>ActivateWindow(MusicLibrary,recentlyaddedalbums)</onclick>
-						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.recent) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="2">
-						<label>$LOCALIZE[31970]</label>
-						<onclick>ActivateWindow(MusicLibrary,recentlyaddedalbums,return)</onclick>
-						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.recent) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(MusicLibrary,recentlyaddedalbums,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.recent)</visible>
 					</item>
 					<item id="3">
 						<label>$LOCALIZE[31971]</label>
-						<onclick>ActivateWindow(MusicLibrary,recentlyplayedalbums)</onclick>
-						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.played) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="3">
-						<label>$LOCALIZE[31971]</label>
-						<onclick>ActivateWindow(MusicLibrary,recentlyplayedalbums,return)</onclick>
-						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.played) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(MusicLibrary,recentlyplayedalbums,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.played)</visible>
 					</item>
 					<item id="4">
 						<label>$LOCALIZE[133]</label>
-						<onclick>ActivateWindow(MusicLibrary,artists)</onclick>
-						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.artists) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="4">
-						<label>$LOCALIZE[133]</label>
-						<onclick>ActivateWindow(MusicLibrary,artists,return)</onclick>
-						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.artists) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(MusicLibrary,artists,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.artists)</visible>
 					</item>
 					<item id="5">
 						<label>$LOCALIZE[135]</label>
-						<onclick>ActivateWindow(MusicLibrary,genres)</onclick>
-						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.genres) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="5">
-						<label>$LOCALIZE[135]</label>
-						<onclick>ActivateWindow(MusicLibrary,genres,return)</onclick>
-						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.genres) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(MusicLibrary,genres,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.genres)</visible>
 					</item>
 					<item id="6">
 						<label>$LOCALIZE[24001]</label>
-						<onclick>ActivateWindow(MusicLibrary,Addons)</onclick>
-						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.addons) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="6">
-						<label>$LOCALIZE[24001]</label>
-						<onclick>ActivateWindow(MusicFiles,Addons,return)</onclick>
-						<visible>!Library.HasContent(music) + Skin.HasSetting(musicmenu.addons) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(MusicLibrary,Addons,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Library.HasContent(music) + Skin.HasSetting(musicmenu.addons)</visible>
 					</item>
 					<item id="8">
 						<label>$LOCALIZE[136]</label>
-						<onclick>ActivateWindow(MusicLibrary,playlists)</onclick>
-						<visible>Skin.HasSetting(musicmenu.playlists) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="8">
-						<label>$LOCALIZE[136]</label>
-						<onclick>ActivateWindow(MusicLibrary,playlists,return)</onclick>
-						<visible>Skin.HasSetting(musicmenu.playlists) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(MusicLibrary,playlists,$INFO[Skin.String(backspacehome)]))</onclick>
+						<visible>Skin.HasSetting(musicmenu.playlists)</visible>
 					</item>
 					<item id="9">
 						<label>$LOCALIZE[589]</label>
@@ -261,7 +226,7 @@
 					</item>
 					<item id="11">
 						<label>$LOCALIZE[20389]</label>
-						<onclick>ActivateWindow(videolibrary,musicvideotitles)</onclick>
+						<onclick>ActivateWindow(videolibrary,musicvideotitles,$INFO[Skin.String(backspacehome)]))</onclick>
 						<visible>Library.HasContent(musicvideos) + Skin.HasSetting(musicmenu.videos)</visible>
 					</item>
 					<item id="12">
@@ -270,7 +235,7 @@
 					</item>
 					<item id="13">
 						<label>$INFO[Skin.String(musicmenu.playlist1.label)]</label>
-						<onclick>ActivateWindow(musiclibrary,$INFO[Skin.String(musicmenu.playlist1.path)],return)</onclick>
+						<onclick>ActivateWindow(musiclibrary,$INFO[Skin.String(musicmenu.playlist1.path)],$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>!IsEmpty(Skin.String(musicmenu.playlist1.path)) + !Skin.HasSetting(favourites.global)</visible>
 					</item>
 					<item id="13">
@@ -358,21 +323,21 @@
 					</item>
 					<item id="8">
 						<label>$LOCALIZE[24033]</label>
-						<onclick>ActivateWindow(addonbrowser,addons://all/)</onclick>
+						<onclick>ActivateWindow(addonbrowser,addons://all/, $INFO[Skin.String(backspacehome)])</onclick>
 					</item>
 					<item id="9">
 						<label>$LOCALIZE[24043]</label>
-						<onclick>ActivateWindow(addonbrowser,addons://outdated/)</onclick>
+						<onclick>ActivateWindow(addonbrowser,addons://outdated/, $INFO[Skin.String(backspacehome)])</onclick>
 						<visible>Skin.HasSetting(addonsmenu.updates)</visible>
 					</item>
 					<item id="10">
 						<label>$LOCALIZE[24062]</label>
-						<onclick>ActivateWindow(addonbrowser,addons://enabled/)</onclick>
+						<onclick>ActivateWindow(addonbrowser,addons://enabled/, $INFO[Skin.String(backspacehome)])</onclick>
 						<visible>Skin.HasSetting(addonsmenu.enabled)</visible>
 					</item>
 					<item id="11">
 						<label>$LOCALIZE[0]</label>
-						<onclick>ActivateWindow(programs,addons, return)</onclick>
+						<onclick>ActivateWindow(programs,addons, $INFO[Skin.String(backspacehome)])</onclick>
 						<visible>Skin.HasSetting(addonsmenu.programs)</visible>
 					</item>
 				</content>
@@ -520,13 +485,7 @@
 				<content>
 					<item id="1">
 						<label>$LOCALIZE[1024]</label>
-						<onclick>ActivateWindow(Videos,MovieTitles)</onclick>
-						<visible>!Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="1">
-						<label>$LOCALIZE[1024]</label>
-						<onclick>ActivateWindow(videolibrary,movietitles,return)</onclick>
-						<visible>Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(Videos,MovieTitles,$INFO[Skin.String(backspacehome)])</onclick>
 					</item>
 					<item id="2">
 						<label>$LOCALIZE[32052]</label>
@@ -537,63 +496,43 @@
 					</item>
 					<item id="3">
 						<label>$LOCALIZE[31095]</label>
-						<onclick>ActivateWindow(Videos,recentlyaddedmovies)</onclick>
-						<visible>Skin.HasSetting(moviesmenu.recent) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="3">
-						<label>$LOCALIZE[31095]</label>
-						<onclick>ActivateWindow(Videos,recentlyaddedmovies,return)</onclick>
-						<visible>Skin.HasSetting(moviesmenu.recent) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(Videos,recentlyaddedmovies,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Skin.HasSetting(moviesmenu.recent)</visible>
 					</item>
 					<item id="4">
 						<label>$LOCALIZE[16101]</label>
-						<onclick>ActivateWindow(Videos,special://skin/playlists/Unwatched Movies.xsp,return)</onclick>
+						<onclick>ActivateWindow(Videos,special://skin/playlists/Unwatched Movies.xsp,$INFO[Skin.String(backspacehome)]))</onclick>
 						<visible>Skin.HasSetting(moviesmenu.unwatched)</visible>
 					</item>
 					<item id="5">
 						<label>$LOCALIZE[575]</label>
-						<onclick>ActivateWindow(videolibrary,special://skin/playlists/Movies In Progress.xsp,return)</onclick>
+						<onclick>ActivateWindow(videolibrary,special://skin/playlists/Movies In Progress.xsp,$INFO[Skin.String(backspacehome)]))</onclick>
 						<visible>Skin.HasSetting(moviesmenu.inprogress)</visible>
 					</item>
 					<item id="6">
 						<label>$LOCALIZE[20434]</label>
-						<onclick>ActivateWindow(Videos,MovieSets,return)</onclick>
+						<onclick>ActivateWindow(Videos,MovieSets,$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>Library.HasContent(MovieSets) + Skin.HasSetting(moviesmenu.sets)</visible>
 					</item>
 					<item id="7">
 						<label>$LOCALIZE[31011]</label>
-						<onclick>XBMC.ActivateWindow(Videos, plugin://plugin.video.the.trailers/)</onclick>
+						<onclick>XBMC.ActivateWindow(Videos, plugin://plugin.video.the.trailers/,$INFO[Skin.String(backspacehome)]))</onclick>
 						<visible>Skin.HasSetting(moviesmenu.trailers) + System.HasAddon(plugin.video.the.trailers)</visible>
 					</item>
 					<item id="8">
 						<label>$LOCALIZE[135]</label>
-						<onclick>ActivateWindow(Videos,moviegenres)</onclick>
-						<visible>Skin.HasSetting(moviesmenu.genres) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="8">
-						<label>$LOCALIZE[135]</label>
-						<onclick>ActivateWindow(Videos,moviegenres,return)</onclick>
-						<visible>Skin.HasSetting(moviesmenu.genres) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(Videos,moviegenres,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Skin.HasSetting(moviesmenu.genres)</visible>
 					</item>
 					<item id="9">
 						<label>$LOCALIZE[652]</label>
-						<onclick>ActivateWindow(Videos,movieyears)</onclick>
-						<visible>Skin.HasSetting(moviesmenu.years) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="9">
-						<label>$LOCALIZE[652]</label>
-						<onclick>ActivateWindow(Videos,movieyears,return)</onclick>
-						<visible>Skin.HasSetting(moviesmenu.years) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(Videos,movieyears,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Skin.HasSetting(moviesmenu.years)</visible>
 					</item>
 					<item id="10">
 						<label>$LOCALIZE[344]</label>
-						<onclick>ActivateWindow(Videos,movieactors)</onclick>
-						<visible>Skin.HasSetting(moviesmenu.actors) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="10">
-						<label>$LOCALIZE[344]</label>
-						<onclick>ActivateWindow(Videos,movieactors,return)</onclick>
-						<visible>Skin.HasSetting(moviesmenu.actors) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(Videos,movieactors,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Skin.HasSetting(moviesmenu.actors)</visible>
 					</item>
 					<item id="11">
 						<label>$LOCALIZE[32011]</label>
@@ -626,13 +565,7 @@
 				<content>
 					<item id="1">
 						<label>$LOCALIZE[1024]</label>
-						<onclick>ActivateWindow(Videos,tvshowtitles)</onclick>
-						<visible>!Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="1">
-						<label>$LOCALIZE[1024]</label>
-						<onclick>ActivateWindow(videolibrary,tvshowtitles,return)</onclick>
-						<visible>Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(Videos,tvshowtitles,$INFO[Skin.String(backspacehome)])</onclick>
 					</item>
 					<item id="2">
 						<label>$LOCALIZE[32052]</label>
@@ -643,53 +576,33 @@
 					</item>
 					<item id="3">
 						<label>$LOCALIZE[31094]</label>
-						<onclick>ActivateWindow(Videos,recentlyaddedepisodes)</onclick>
-						<visible>Skin.HasSetting(tvshowsmenu.recent) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="3">
-						<label>$LOCALIZE[31094]</label>
-						<onclick>ActivateWindow(Videos,recentlyaddedepisodes,return)</onclick>
-						<visible>Skin.HasSetting(tvshowsmenu.recent) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(Videos,recentlyaddedepisodes,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Skin.HasSetting(tvshowsmenu.recent)</visible>
 					</item>
 					<item id="4">
 						<label>$LOCALIZE[16101]</label>
-						<onclick>ActivateWindow(Videos,special://skin/playlists/Unwatched Episodes.xsp,return)</onclick>
+						<onclick>ActivateWindow(Videos,special://skin/playlists/Unwatched Episodes.xsp,$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>Skin.HasSetting(tvshowsmenu.unwatched)</visible>
 					</item>
 					<item id="5">
 						<label>$LOCALIZE[575]</label>
-						<onclick>ActivateWindow(Videos,library://video/inprogressshows.xml,return)</onclick>
+						<onclick>ActivateWindow(Videos,library://video/inprogressshows.xml,$INFO[Skin.String(backspacehome)])</onclick>
 						<visible>Skin.HasSetting(tvshowsmenu.inprogress)</visible>
 					</item>
 					<item id="6">
 						<label>$LOCALIZE[135]</label>
-						<onclick>ActivateWindow(Videos,tvshowgenres)</onclick>
-						<visible>Skin.HasSetting(tvshowsmenu.genres) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="6">
-						<label>$LOCALIZE[135]</label>
-						<onclick>ActivateWindow(Videos,tvshowgenres,return)</onclick>
-						<visible>Skin.HasSetting(tvshowsmenu.genres) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(Videos,tvshowgenres,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Skin.HasSetting(tvshowsmenu.genres)</visible>
 					</item>
 					<item id="7">
 						<label>$LOCALIZE[652]</label>
-						<onclick>ActivateWindow(Videos,tvshowyears)</onclick>
-						<visible>Skin.HasSetting(tvshowsmenu.years) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="7">
-						<label>$LOCALIZE[652]</label>
-						<onclick>ActivateWindow(Videos,tvshowyears,return)</onclick>
-						<visible>Skin.HasSetting(tvshowsmenu.years) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(Videos,tvshowyears,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Skin.HasSetting(tvshowsmenu.years)</visible>
 					</item>
 					<item id="8">
 						<label>$LOCALIZE[344]</label>
-						<onclick>ActivateWindow(Videos,tvshowactors)</onclick>
-						<visible>Skin.HasSetting(tvshowsmenu.actors) + !Skin.HasSetting(backspacehome.enable)</visible>
-					</item>
-					<item id="8">
-						<label>$LOCALIZE[344]</label>
-						<onclick>ActivateWindow(Videos,tvshowactors,return)</onclick>
-						<visible>Skin.HasSetting(tvshowsmenu.actors) + Skin.HasSetting(backspacehome.enable)</visible>
+						<onclick>ActivateWindow(Videos,tvshowactors,$INFO[Skin.String(backspacehome)])</onclick>
+						<visible>Skin.HasSetting(tvshowsmenu.actors)</visible>
 					</item>
 					<item id="9">
 						<label>$LOCALIZE[31070]</label>

--- a/720p/SkinSettings.xml
+++ b/720p/SkinSettings.xml
@@ -709,8 +709,9 @@
 			<!--backspace to home-->
 			<control type="radiobutton" id="901">
 				<label>$LOCALIZE[32000]</label>
-				<onclick>Skin.ToggleSetting(backspacehome.enable)</onclick>
-				<selected>Skin.HasSetting(backspacehome.enable)</selected>
+				<onclick condition="Skin.String(backspacehome,return)">Skin.SetString(backspacehome,)</onclick>
+				<onclick condition="!Skin.String(backspacehome,return)">Skin.SetString(backspacehome, return)</onclick>
+				<selected>Skin.String(backspacehome,return)</selected>
 				<include>button_Settings</include>
 			</control>
 			<!--smooth scrolling-->


### PR DESCRIPTION
I've reworked the homemenu because I've had a couple of problems (couldn't enable the Addons in the music menu for example). Anyway I saw that you have the same problem I had when I was working on my mod. You have most menu buttons listed twice with a visible condition based on backspacehome.enable but this isn't really necessary because instead of setting a boolean value you can just save the "return" in a string and feed that to the ActivateWindow function:

``` xml
<onclick>ActivateWindow(Videos,MovieTitles,$INFO[Skin.String(backspacehome)])</onclick>
```

And in the SkinSettings.xml:

``` xml
<onclick condition="Skin.String(backspacehome,return)">Skin.SetString(backspacehome,)</onclick>
<onclick condition="!Skin.String(backspacehome,return)">Skin.SetString(backspacehome, return)</onclick>
<selected>Skin.String(backspacehome,return)</selected>
```

This allows for a much cleaner HomeSubMenu.xml and prevents bugs because you only have to write code once. There were a lot of menu entries that didn't have the return parameter at all or were hardcoded so I've added the same $INFO tag to them to provide some consistency. This has been tested with pretty much every menu entry except the live TV ones because I don't have the PVR functionality.

I've also made it so when you return to the homescreen you'll return to the submenu you were last in.

I've added the following to the Home.xml to make sure the user doesn't have to reconfigure the skin settings:

``` xml
<onload condition="Skin.HasSetting(backspacehome.enable) + !Skin.HasSetting(backspacehome.upgraded)">Skin.SetString(backspacehome, return)</onload>
<onload condition="!Skin.HasSetting(backspacehome.upgraded)">Skin.SetBool(backspacehome.upgraded)</onload>
```

This should probably be removed after everyone upgraded.

Please tell me what you think about this and if would merge this into your branch so I can get to work on the home menu settings. There are a couple of bugs (Movie Sets are listed twice for example) and a lot of missing entries (Directors, Tags, etc.)
